### PR TITLE
Set nonce lifetime in example

### DIFF
--- a/test/Main.hs
+++ b/test/Main.hs
@@ -68,5 +68,5 @@ main :: IO ()
 main =
   do [clientId, clientSecret, callback] <- fmap T.pack <$> getArgs
      let oa = gh clientId clientSecret callback
-     oauthState <- OA.newOAuthState
+     oauthState <- OA.newOAuthStateWith oauthStateNonce
      run 8181 (serve api (server oa oauthState))

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -41,7 +41,7 @@ gh cid csecret callback =
             , oauthClientSecret = csecret
             , oauthOAuthorizeEndpoint = "https://github.com/login/oauth/authorize"
             , oauthAccessTokenEndpoint = "https://github.com/login/oauth/access_token"
-            , oauthCallback = callback -- e.x. http://127.0.0.1/authorized
+            , oauthCallback = callback -- e.x. http://127.0.0.1:8181/authorized
             , oauthScopes = []
             }
 


### PR DESCRIPTION
`verifyOAuthNonce` returns `Nothing` if its first argument is `OAuthStateless`. `getAuthorized` returns `Nothing` if `verifyOAuthNonce` returns `Nothing`.

In this PR I've fixed the example to use `OAuthStateConfig` instead of `OAuthStatelessConfig`. But I think the library itself has a problem: I think that trying to authenticate using `newOAuthState` which uses `OAuthStatelessConfig` currently does not work due to the above.